### PR TITLE
Fix module resolution

### DIFF
--- a/src/core/checks/dependency/DependOnStrategy.ts
+++ b/src/core/checks/dependency/DependOnStrategy.ts
@@ -82,8 +82,10 @@ export class DependOnStrategy implements CheckStrategy {
 	): ImportDeclaration | null {
 		let result: ImportDeclaration | null = null
 		this.getImportDeclarations(subject).forEach(i => {
-			const assumedPath = PathHelper.assumePathOfImportedObject(subject, i)
-
+			const assumedPath = PathHelper.assumePathOfImportedObject(subject.getSourceFile().fileName, i)
+			if (!assumedPath) {
+				return
+			}
 			if (
 				DependOnStrategy.hasSuffix(assumedPath, "ts") &&
 				this.pathsMatch(assumedPath, object)

--- a/src/core/checks/dependency/PathHelper.ts
+++ b/src/core/checks/dependency/PathHelper.ts
@@ -1,23 +1,21 @@
-import { File } from "../../noun/File"
-import { ImportDeclaration } from "typescript"
-import * as path from "path"
+import * as ts from "typescript"
 
 export class PathHelper {
-	public static assumePathOfImportedObject(subject: File, i: ImportDeclaration) {
-		let completePath = subject.getPath()
-		const assumedPathTokens = [
-			...completePath.split("/"),
-			...i.moduleSpecifier["text"].split("/")
-		]
-		return PathHelper.assemblePath(assumedPathTokens, completePath)
-	}
+	public static assumePathOfImportedObject(subject: string, i: ts.ImportDeclaration) {
+		const moduleSpecifier = i.moduleSpecifier["text"]
+		let completePath = subject
 
-	private static assemblePath(tokens: string[], completePath: string) {
-		let pathWithoutTrailingSlash = path.join(...tokens)
-		if (completePath.startsWith('/')) {
-			return '/'+pathWithoutTrailingSlash
-		} else {
-			return pathWithoutTrailingSlash
+		let resolvedModule = ts.resolveModuleName(
+			moduleSpecifier,
+			completePath,
+			{},
+			ts.createCompilerHost({}, true)
+		).resolvedModule
+
+		if (!resolvedModule) {
+			return undefined
 		}
+		
+		return resolvedModule.resolvedFileName
 	}
 }


### PR DESCRIPTION
# Summary
The PathHelper used to perform module resolution using a customs heuristics. When it comes to node_modules, however, this heuristic is not exact. In this pr we replace it by using the resolution strategy of the typescript compiler itself.

# Possible enhancements
Currently, the IgnoreConfig is applied in DependOnStrategy. One could extend ProjectParser to actually read and process tsconfig.json. Then one could also use this configuration in PathHelper.