### PR TITLE
Allow tsx in projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -346,16 +346,14 @@
       "dev": true
     },
     "@types/events": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
-      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
     },
     "@types/glob": {
-      "version": "5.0.35",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
-      "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
-      "dev": true,
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
       "requires": {
         "@types/events": "*",
         "@types/minimatch": "*",
@@ -371,14 +369,12 @@
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-      "dev": true
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
       "version": "10.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.5.2.tgz",
-      "integrity": "sha512-m9zXmifkZsMHZBOyxZWilMwmTlpC8x5Ty360JKTiXvlXZfBWYpsg9ZZvP/Ye+iZUh+Q+MxDLjItVTWIsfwz+8Q==",
-      "dev": true
+      "integrity": "sha512-m9zXmifkZsMHZBOyxZWilMwmTlpC8x5Ty360JKTiXvlXZfBWYpsg9ZZvP/Ye+iZUh+Q+MxDLjItVTWIsfwz+8Q=="
     },
     "JSONStream": {
       "version": "1.3.3",
@@ -3786,8 +3782,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3811,15 +3806,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3836,22 +3829,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3982,8 +3972,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3997,7 +3986,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4014,7 +4002,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4023,15 +4010,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4052,7 +4037,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4141,8 +4125,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4156,7 +4139,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4252,8 +4234,7 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4295,7 +4276,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4317,7 +4297,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4366,15 +4345,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -7861,7 +7838,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "clean": "rimraf dist",
     "prebuild": "rimraf dist",
     "prepush": "npm run test:prod && npm run lint && npm run build && npm run clean",
-    "build": "tsc --module commonjs && typedoc --out docs --target es6 --theme minimal --mode file src",
+    "build": "tsc && typedoc --out docs --target es6 --theme minimal --mode file src",
     "test": "jest --no-cache",
     "test:watch": "jest --watch --no-cache",
     "test:clear": "jest --clearCache",
@@ -102,8 +102,9 @@
     "validate-commit-msg": "^2.12.2"
   },
   "dependencies": {
+    "@types/glob": "^7.1.1",
     "fs": "0.0.1-security",
-    "typescript": "^3.3.4000",
-    "path": "^0.12.7"
+    "path": "^0.12.7",
+    "typescript": "^3.3.4000"
   }
 }

--- a/src/core/parser/ProjectParser.ts
+++ b/src/core/parser/ProjectParser.ts
@@ -2,12 +2,14 @@ import { createProgram, ScriptTarget } from "typescript"
 import { FileFactory } from "../noun/FileFactory"
 import { Project } from "../Project"
 import { IgnoreConfig } from "../TSArchConfig";
+import * as glob from 'glob'
+
 export class ProjectParser {
 	public static async parse(
 		rootPath: string,
 		config: IgnoreConfig
 	): Promise<Project> {
-		const glob = config.js ? "**/*.ts" : "**/*.[jt]s"
+		const glob = config.js ? "**/*.{ts,tsx}" : "**/*.{ts,tsx,js,jsx}"
 		const fileNames = await ProjectParser.getFileNames(rootPath + glob)
 		const project = new Project()
 
@@ -30,7 +32,6 @@ export class ProjectParser {
 
 	public static async getFileNames(globPattern: string): Promise<string[]> {
 		return new Promise<string[]>((resolve, reject) => {
-			const glob = require("glob")
 			glob(globPattern, (err, files: string[]) => {
 				if (err) {
 					reject(err)

--- a/test/integration/dependencies.spec.ts
+++ b/test/integration/dependencies.spec.ts
@@ -1,0 +1,32 @@
+import { TSArch } from "../../src/core/TSArch"
+
+describe('Type script dependencies', () =>{
+
+	it ('pure typescript', async () => {
+		const project = await TSArch.parseTypescriptProject(__dirname + "/ts/")
+
+		const rule = TSArch.defineThat()
+			.files()
+			.withPathMatching(/client/)
+			.shouldNot()
+			.dependOn()
+			.files()
+			.withPathMatching(/server/)
+			.build()
+		expect(project.check(rule).hasRulePassed()).toBeFalsy();
+	})
+
+	it ('typescript and tsx mixed', async () => {
+		const project = await TSArch.parseTypescriptProject(__dirname + "/tsx/")
+
+		const rule = TSArch.defineThat()
+			.files()
+			.withPathMatching(/client/)
+			.shouldNot()
+			.dependOn()
+			.files()
+			.withPathMatching(/server/)
+			.build()
+		expect(project.check(rule).hasRulePassed()).toBeFalsy();
+	})
+})

--- a/test/integration/ts/client/ClientDependency.ts
+++ b/test/integration/ts/client/ClientDependency.ts
@@ -1,0 +1,5 @@
+import { serverFunction } from "../server/ServerDependency"
+
+export function someString() {
+	return serverFunction()
+}

--- a/test/integration/ts/server/ServerDependency.ts
+++ b/test/integration/ts/server/ServerDependency.ts
@@ -1,0 +1,3 @@
+export function serverFunction(): string {
+	return "String from Server";
+}

--- a/test/integration/tsx/client/ClientDependency.tsx
+++ b/test/integration/tsx/client/ClientDependency.tsx
@@ -1,0 +1,5 @@
+import { serverFunction } from "../server/ServerDependency"
+
+export function SomeHtml() {
+	return ( <div> {serverFunction()} </div> )
+}

--- a/test/integration/tsx/server/ServerDependency.ts
+++ b/test/integration/tsx/server/ServerDependency.ts
@@ -1,0 +1,3 @@
+export function serverFunction(): string {
+	return "String from Server";
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "target": "es5",
+    "module":"commonjs",
+    "lib": ["es2015", "es2016", "es2017"],
+    "strict": true,
+    "sourceMap": true,
+    "declaration": true,
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "declarationDir": "dist",
+    "noImplicitAny": false,
+    "outDir": "dist",
+	"noEmit": true,
+    "typeRoots": [
+      "node_modules/@types"
+    ],
+	"jsx": "preserve"
+  },
+  "include": [
+    "."
+  ]
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -15,7 +15,7 @@
     "outDir": "dist",
 	"noEmit": true,
     "typeRoots": [
-      "node_modules/@types"
+      "../node_modules/@types"
     ],
 	"jsx": "preserve"
   },


### PR DESCRIPTION
# Summary 
In this PR we allow tsx/jsx in projects. Support was in principle already present, only the project importer ignored tsx files until now. 
Rough integration tests to test dependency checks end-to-end were added.