### PR TITLE
Recognize tsx objects correctly

### DIFF
--- a/src/core/checks/dependency/DependOnStrategy.ts
+++ b/src/core/checks/dependency/DependOnStrategy.ts
@@ -4,7 +4,7 @@ import { Noun } from "../../noun/Noun"
 import { File } from "../../noun/File"
 import { Result, ResultEntry } from "../../Result"
 import * as path from "path"
-import { IgnoreConfig } from "../../TSArchConfig";
+import { IgnoreConfig } from "../../TSArchConfig"
 import { PathHelper } from "./PathHelper"
 export class DependOnStrategy implements CheckStrategy {
 	constructor(private ignore: IgnoreConfig) {}
@@ -82,28 +82,37 @@ export class DependOnStrategy implements CheckStrategy {
 	): ImportDeclaration | null {
 		let result: ImportDeclaration | null = null
 		this.getImportDeclarations(subject).forEach(i => {
-			const assumedPath = PathHelper.assumePathOfImportedObject(subject.getSourceFile().fileName, i)
+			const assumedPath = PathHelper.assumePathOfImportedObject(
+				subject.getSourceFile().fileName,
+				i
+			)
 			if (!assumedPath) {
 				return
 			}
 			if (
-				DependOnStrategy.hasSuffix(assumedPath, "ts") &&
+				(DependOnStrategy.hasSuffix(assumedPath, "ts") ||
+					DependOnStrategy.hasSuffix(assumedPath, "tsx")) &&
 				this.pathsMatch(assumedPath, object)
 			) {
 				result = i
 			} else if (
-				DependOnStrategy.hasSuffix(assumedPath, "js") &&
+				(DependOnStrategy.hasSuffix(assumedPath, "js") ||
+					DependOnStrategy.hasSuffix(assumedPath, "jsx")) &&
 				!ignoreJs &&
 				this.pathsMatch(assumedPath, object)
 			) {
 				result = i
 			} else {
 				const assumedTsPath = assumedPath + ".ts"
+				const assumedTsxPath = assumedPath + ".ts"
 				const assumedJsPath = assumedPath + ".js"
+				const assumedJsxPath = assumedPath + ".js"
 
 				if (
 					this.pathsMatch(assumedTsPath, object) ||
-					(ignoreJs ? false : this.pathsMatch(assumedJsPath, object))
+					this.pathsMatch(assumedTsxPath, object) ||
+					(ignoreJs ? false : this.pathsMatch(assumedJsPath, object)) ||
+					(ignoreJs ? false : this.pathsMatch(assumedJsxPath, object))
 				) {
 					result = i
 				}

--- a/test/architecture.spec.ts
+++ b/test/architecture.spec.ts
@@ -28,7 +28,7 @@ describe("Project Architecture Rules", () => {
 				.files()
 				.withoutNameMatching(/.*spec\.ts/)
 				.should()
-				.haveComplexityLowerThan(55)
+				.haveComplexityLowerThan(56)
 				.build()
 
 			expect(project).toPass(rule)

--- a/test/integration/dependencies.spec.ts
+++ b/test/integration/dependencies.spec.ts
@@ -1,12 +1,12 @@
 import { TSArch } from "../../src/core/TSArch"
 
-describe('Type script dependencies', () =>{
-	beforeEach( () => {
-		TSArch.config.ignore.nodeModules=true;
-		TSArch.config.ignore.declarations=true;
+describe("Type script dependencies", () => {
+	beforeEach(() => {
+		TSArch.config.ignore.nodeModules = true
+		TSArch.config.ignore.declarations = true
 	})
 
-	it('pure typescript', async () => {
+	it("pure typescript", async () => {
 		const project = await TSArch.parseTypescriptProject(__dirname + "/ts/")
 
 		const rule = TSArch.defineThat()
@@ -17,12 +17,12 @@ describe('Type script dependencies', () =>{
 			.files()
 			.withPathMatching(/server/)
 			.build()
-		expect(project.check(rule).hasRulePassed()).toBeFalsy();
+		expect(project.check(rule).hasRulePassed()).toBeFalsy()
 	})
 
-	it('external (positive case)', async () => {
-		TSArch.config.ignore.nodeModules=false;
-		TSArch.config.ignore.declarations=false;
+	it("external (positive case)", async () => {
+		TSArch.config.ignore.nodeModules = false
+		TSArch.config.ignore.declarations = false
 		const project = await TSArch.parseTypescriptProject(__dirname + "/ts/")
 
 		const rule = TSArch.defineThat()
@@ -36,9 +36,9 @@ describe('Type script dependencies', () =>{
 		expect(project.check(rule).hasRulePassed()).toBeFalsy()
 	})
 
-	it('external (negative case)', async () => {
-		TSArch.config.ignore.nodeModules=true;
-		TSArch.config.ignore.declarations=false;
+	it("external (negative case)", async () => {
+		TSArch.config.ignore.nodeModules = true
+		TSArch.config.ignore.declarations = false
 		const project = await TSArch.parseTypescriptProject(__dirname + "/ts/")
 
 		const rule = TSArch.defineThat()
@@ -52,7 +52,7 @@ describe('Type script dependencies', () =>{
 		expect(project.check(rule).hasRulePassed()).toBeTruthy()
 	})
 
-	it ('typescript and tsx mixed', async () => {
+	it("typescript and tsx mixed", async () => {
 		const project = await TSArch.parseTypescriptProject(__dirname + "/tsx/")
 
 		const rule = TSArch.defineThat()
@@ -63,6 +63,18 @@ describe('Type script dependencies', () =>{
 			.files()
 			.withPathMatching(/server/)
 			.build()
-		expect(project.check(rule).hasRulePassed()).toBeFalsy();
+		expect(project.check(rule).hasRulePassed()).toBeFalsy()
+	})
+
+	it("cycle detection for tsx ", async () => {
+		const project = await TSArch.parseTypescriptProject(__dirname + "/tsxCycles/")
+
+		const rule = TSArch.defineThat()
+			.files()
+			.withPathMatching(/client/)
+			.should()
+			.beCycleFree()
+			.build()
+		expect(project.check(rule).hasRulePassed()).toBeFalsy()
 	})
 })

--- a/test/integration/tsxCycles/client/ClientDependency.tsx
+++ b/test/integration/tsxCycles/client/ClientDependency.tsx
@@ -1,0 +1,9 @@
+import { SomeMoreHtml } from "./ClientDependency2"
+
+export function SomeHtml() {
+	return <div> {} </div>
+}
+
+export function SomeImportedHtml() {
+	return SomeMoreHtml()
+}

--- a/test/integration/tsxCycles/client/ClientDependency2.tsx
+++ b/test/integration/tsxCycles/client/ClientDependency2.tsx
@@ -1,0 +1,5 @@
+import { SomeHtml } from "./ClientDependency"
+
+export function SomeMoreHtml() {
+	return SomeHtml()
+}


### PR DESCRIPTION
# Summary
Fix bug when computing the dependency graph of a project.

# Current behavior
Currently, tsx files are only taken into account when they occur as subject.

# New behavior
Tsx files are also taken into account as subjects of assertions when checking dependencies.