### PR TITLE
Construct slice patterns correctly

### DIFF
--- a/src/slices/projection/slicingProjections.spec.ts
+++ b/src/slices/projection/slicingProjections.spec.ts
@@ -1,0 +1,31 @@
+import { sliceByPattern } from "./slicingProjections"
+
+describe("slicingProjections", () => {
+	it("slices sub directories", () => {
+		const edge = {
+			source: "src/service/blub/Service.ts",
+			target: "src/facade/bla/Facade.ts",
+			external: false
+		}
+		expect(sliceByPattern("src/(**)/")(edge)?.sourceLabel).toEqual("service")
+		expect(sliceByPattern("src/(**)/")(edge)?.targetLabel).toEqual("facade")
+	})
+
+	it("slices on top level", () => {
+		const edge = {
+			source: "src/service/Service.ts",
+			target: "src/facade/Facade.ts",
+			external: false
+		}
+		expect(sliceByPattern("src/(**)")(edge)?.sourceLabel).toEqual("service")
+		expect(sliceByPattern("src/(**)")(edge)?.targetLabel).toEqual("facade")
+	})
+
+	it("detects missing '(**)' in slice pattern", () => {
+		expect(() => sliceByPattern("src/(*")).toThrowError()
+	})
+
+	it("slices too many occurances of '(**)' in slice pattern", () => {
+		expect(() => sliceByPattern("src/(**)/(**)")).toThrowError()
+	})
+})

--- a/src/slices/projection/slicingProjections.ts
+++ b/src/slices/projection/slicingProjections.ts
@@ -1,10 +1,29 @@
 import { Edge } from "../../common/extraction/graph"
 import { safeArrayGet } from "../../common/util/arrayUtils"
-import {MapFunction, MappedEdge} from "../../common/projection/projectEdges";
+import { MapFunction, MappedEdge } from "../../common/projection/projectEdges"
 
 export function sliceByPattern(pattern: string): MapFunction {
-	const regexp = pattern.replace("(**)", "([\\w].+)")
-	return sliceByRegex(new RegExp(`^${regexp}`))
+	const index = pattern.indexOf("(**)")
+	if (index === -1) {
+		throw new Error(
+			"Could not find '(**)' inside slice pattern. It should contain exactly one occurance'(**)'"
+		)
+	}
+	const prefix = escapeForRegexp(pattern.substr(0, index))
+	const unescapedSuffix = pattern.substr(index + 4, pattern.length)
+	if (unescapedSuffix.indexOf("(**)") !== -1) {
+		throw new Error(
+			"Found too many '(**)' inside slice pattern. It should contain exactly one occurance'(**)'"
+		)
+	}
+
+	const suffix = escapeForRegexp(unescapedSuffix)
+	const regexp = `^${prefix}([\\w]+)${suffix}.*$`
+	return sliceByRegex(new RegExp(regexp))
+}
+
+function escapeForRegexp(input: string): string {
+	return input.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&")
 }
 
 export function sliceByRegex(regexp: RegExp): MapFunction {

--- a/test/slices/integration/integration.spec.ts
+++ b/test/slices/integration/integration.spec.ts
@@ -3,13 +3,15 @@ import { parse } from "plantuml-parser"
 import { slicesOfProject } from "../../../src/slices/fluentapi/slices"
 import { exportDiagram } from "../../../src/slices/uml/exportDiagram"
 import path from "path"
-import {extractGraph} from "../../../src/common/extraction/extractGraph";
-import {sliceByFileSuffix, sliceByPattern} from "../../../src/slices/projection/slicingProjections";
-import {projectEdges} from "../../../src/common/projection/projectEdges";
-import {gatherPositiveViolations} from "../../../src/slices/assertion/admissibleEdges";
+import { extractGraph } from "../../../src/common/extraction/extractGraph"
+import {
+	sliceByFileSuffix,
+	sliceByPattern
+} from "../../../src/slices/projection/slicingProjections"
+import { projectEdges } from "../../../src/common/projection/projectEdges"
+import { gatherPositiveViolations } from "../../../src/slices/assertion/admissibleEdges"
 
 describe("Integration test", () => {
-
 	it("finds simple violations", async () => {
 		const violations = await slicesOfProject(__dirname + "/samples/foldersample/tsconfig.json")
 			.definedBy("src/(**)/")
@@ -23,7 +25,7 @@ describe("Integration test", () => {
 				targetLabel: "controllers",
 				cumulatedEdges: [
 					{
-						source: "src/services/Service.ts",
+						source: "src/services/util/Service.ts",
 						target: "src/controllers/Controller.ts",
 						external: false
 					}
@@ -34,9 +36,7 @@ describe("Integration test", () => {
 	})
 
 	it("reports inner dependencies", async () => {
-		const graph = (
-			await extractGraph(__dirname + "/samples/innerdependencies/tsconfig.json")
-		)
+		const graph = await extractGraph(__dirname + "/samples/innerdependencies/tsconfig.json")
 
 		const mapFunction = sliceByPattern("src/facades/(**)/")
 
@@ -81,7 +81,7 @@ describe("Integration test", () => {
 				targetLabel: "controllers",
 				cumulatedEdges: [
 					{
-						source: "src/services/Service.ts",
+						source: "src/services/util/Service.ts",
 						target: "src/controllers/Controller.ts",
 						external: false
 					}
@@ -108,7 +108,7 @@ describe("Integration test", () => {
 				targetLabel: "controllers",
 				cumulatedEdges: [
 					{
-						source: "src/services/Service.ts",
+						source: "src/services/util/Service.ts",
 						target: "src/controllers/Controller.ts",
 						external: false
 					}
@@ -118,9 +118,7 @@ describe("Integration test", () => {
 	})
 
 	it("exports the architecture by suffixes", async () => {
-		const graph = (
-			await extractGraph(__dirname + "/samples/suffixsample/tsconfig.json")
-		)
+		const graph = await extractGraph(__dirname + "/samples/suffixsample/tsconfig.json")
 
 		const mapFunction = sliceByFileSuffix(
 			new Map([
@@ -148,9 +146,7 @@ describe("Integration test", () => {
 	})
 
 	it("exports the architecture by folders", async () => {
-		const graph = (
-			await extractGraph(__dirname + "/samples/foldersample/tsconfig.json")
-		)
+		const graph = await extractGraph(__dirname + "/samples/foldersample/tsconfig.json")
 		const mapFunction = sliceByPattern("src/(**)/")
 
 		const reducedGraph = projectEdges(graph, mapFunction)

--- a/test/slices/integration/samples/foldersample/src/controllers/Controller.ts
+++ b/test/slices/integration/samples/foldersample/src/controllers/Controller.ts
@@ -1,1 +1,1 @@
-import "../services/Service"
+import "../services/util/Service"

--- a/test/slices/integration/samples/foldersample/src/services/Service.ts
+++ b/test/slices/integration/samples/foldersample/src/services/Service.ts
@@ -1,1 +1,0 @@
-import "../controllers/Controller"

--- a/test/slices/integration/samples/foldersample/src/services/util/Service.ts
+++ b/test/slices/integration/samples/foldersample/src/services/util/Service.ts
@@ -1,0 +1,1 @@
+import "../../controllers/Controller"


### PR DESCRIPTION
# Content

In this PR I fix the bug that pathes like "src/facades/util" are sliced to "facades/util" w.r.t. to the slice pattern "src/(**)/" where as "facades" would be correct.

# Testing

Unit tests where added for the slicing of paths.