### PR TITLE
Support absolute paths in tsconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -930,6 +930,30 @@
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
     },
+    "@zerollup/ts-helpers": {
+      "version": "1.7.18",
+      "resolved": "https://registry.npmjs.org/@zerollup/ts-helpers/-/ts-helpers-1.7.18.tgz",
+      "integrity": "sha512-S9zN+y+i5yN/evfWquzSO3lubqPXIsPQf6p9OiPMpRxDx/0totPLF39XoRw48Dav5dSvbIE8D2eAPpXXJxvKwg==",
+      "requires": {
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "path-parse": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+        },
+        "resolve": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "requires": {
+            "is-core-module": "^2.1.0",
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -4843,8 +4867,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -5099,7 +5122,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -5527,6 +5549,14 @@
       "dev": true,
       "requires": {
         "ci-info": "^1.0.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "requires": {
+        "has": "^1.0.3"
       }
     },
     "is-data-descriptor": {
@@ -12084,7 +12114,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
 		"validate-commit-msg": "^2.12.2"
 	},
 	"dependencies": {
+		"@zerollup/ts-helpers": "^1.7.18",
 		"fs": "0.0.1-security",
 		"path": "^0.12.7",
 		"plantuml-parser": "0.0.16",

--- a/test/files/integration/integration.spec.ts
+++ b/test/files/integration/integration.spec.ts
@@ -1,10 +1,9 @@
-import {FileConditionBuilder, filesOfProject} from "../../../src/files/fluentapi/files";
-
+import { FileConditionBuilder, filesOfProject } from "../../../src/files/fluentapi/files"
+import path from "path"
 describe("Integration test", () => {
-
 	let files: FileConditionBuilder
 
-	beforeAll(()=>{
+	beforeAll(() => {
 		files = filesOfProject(__dirname + "/samples/namingsample/tsconfig.json")
 	})
 
@@ -12,7 +11,7 @@ describe("Integration test", () => {
 		const violations = await files
 			.inFolder("controllers")
 			.should()
-			.matchPattern(".*Controller\.ts")
+			.matchPattern(".*Controller.ts")
 			.check()
 
 		expect(violations).toEqual([])
@@ -22,27 +21,58 @@ describe("Integration test", () => {
 		const violations = await files
 			.inFolder("controllers")
 			.should()
-			.matchPattern(".*Service\.ts")
+			.matchPattern(".*Service.ts")
 			.check()
 
-		expect(violations).toEqual([{"checkPattern": ".*Service.ts", "projectedNode": {"label": "src/controllers/Controller.ts"}}])
+		expect(violations).toEqual([
+			{ checkPattern: ".*Service.ts", projectedNode: { label: "src/controllers/Controller.ts" } }
+		])
 	})
 
 	it("does find a violation when described as negated rule", async () => {
 		const violations = await files
 			.inFolder("controllers")
 			.shouldNot()
-			.matchPattern(".*Controller\.ts")
+			.matchPattern(".*Controller.ts")
 			.check()
 
-		expect(violations).toEqual([{"checkPattern": ".*Controller.ts", "projectedNode": {"label": "src/controllers/Controller.ts"}}])
+		expect(violations).toEqual([
+			{ checkPattern: ".*Controller.ts", projectedNode: { label: "src/controllers/Controller.ts" } }
+		])
+	})
+
+	it("handles absolute imports", async () => {
+		const violations = await filesOfProject(
+			path.resolve(__dirname, "samples", "absoluteimports", "tsconfig.json")
+		)
+			.matchingPattern("src/components/ATest")
+			.shouldNot()
+			.dependOnFiles()
+			.matchingPattern("src/components/BTest")
+			.check()
+
+		expect(violations).toEqual([
+			{
+				dependency: {
+					cumulatedEdges: [
+						{
+							external: false,
+							source: "src/components/ATest/ATest.ts",
+							target: "src/components/BTest/BTest.ts"
+						}
+					],
+					sourceLabel: "src/components/ATest/ATest.ts",
+					targetLabel: "src/components/BTest/BTest.ts"
+				}
+			}
+		])
 	})
 
 	it("does not find a violation when described as negated rule", async () => {
 		const violations = await files
 			.inFolder("controllers")
 			.shouldNot()
-			.matchPattern(".*Service\.ts")
+			.matchPattern(".*Service.ts")
 			.check()
 
 		expect(violations).toEqual([])
@@ -53,19 +83,42 @@ describe("Integration test", () => {
 			.inFolder("controllers")
 			.inFolder("services")
 			.should()
-			.matchPattern(".*Service\.ts")
+			.matchPattern(".*Service.ts")
 			.check()
 
 		expect(violations).toEqual([])
 	})
 
 	it("checks for cycles", async () => {
-		const violations = await files
-			.matchingPattern(".*")
-			.should()
-			.beFreeOfCycles()
-			.check()
+		const violations = await files.matchingPattern(".*").should().beFreeOfCycles().check()
 
-		expect(violations).toEqual([{"cycle": [{"cumulatedEdges": [{"external": false, "source": "src/services/Service.ts", "target": "src/controllers/Controller.ts"}], "sourceLabel": "src/services/Service.ts", "targetLabel": "src/controllers/Controller.ts"}, {"cumulatedEdges": [{"external": false, "source": "src/controllers/Controller.ts", "target": "src/services/Service.ts"}], "sourceLabel": "src/controllers/Controller.ts", "targetLabel": "src/services/Service.ts"}]}])
+		expect(violations).toEqual([
+			{
+				cycle: [
+					{
+						cumulatedEdges: [
+							{
+								external: false,
+								source: "src/services/Service.ts",
+								target: "src/controllers/Controller.ts"
+							}
+						],
+						sourceLabel: "src/services/Service.ts",
+						targetLabel: "src/controllers/Controller.ts"
+					},
+					{
+						cumulatedEdges: [
+							{
+								external: false,
+								source: "src/controllers/Controller.ts",
+								target: "src/services/Service.ts"
+							}
+						],
+						sourceLabel: "src/controllers/Controller.ts",
+						targetLabel: "src/services/Service.ts"
+					}
+				]
+			}
+		])
 	})
 })

--- a/test/files/integration/samples/absoluteimports/src/components/ATest/ATest.ts
+++ b/test/files/integration/samples/absoluteimports/src/components/ATest/ATest.ts
@@ -1,0 +1,1 @@
+import "@components/BTest/BTest"

--- a/test/files/integration/samples/absoluteimports/src/components/BTest/BTest.ts
+++ b/test/files/integration/samples/absoluteimports/src/components/BTest/BTest.ts
@@ -1,0 +1,1 @@
+import "@components/ATest/ATest"

--- a/test/files/integration/samples/absoluteimports/tsconfig.json
+++ b/test/files/integration/samples/absoluteimports/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		/* Basic Options */
 		"target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
 		"module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
@@ -12,7 +13,7 @@
 		// "sourceMap": true,                     /* Generates corresponding '.map' file. */
 		// "outFile": "./",                       /* Concatenate and emit output to single file. */
 		// "outDir": "./",                        /* Redirect output structure to the directory. */
-		"rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
+		"rootDir": "." /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
 		// "composite": true,                     /* Enable projectCycles compilation */
 		// "removeComments": true,                /* Do not emit comments to output. */
 		"noEmit": true /* Do not emit outputs. */,
@@ -36,14 +37,14 @@
 		// "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
 		/* Module Resolution Options */
-		"moduleResolution": "node" /* Specify module resolution strategy: 'node' (NumberNode.js) or 'classic' (TypeScript pre-1.6). */,
+		// "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (NumberNode.js) or 'classic' (TypeScript pre-1.6). */
 		// "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
 		// "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
 		// "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the projectCycles at runtime. */
 		// "typeRoots": [],                       /* List of folders to include type definitions from. */
 		// "types": [],                           /* Type declaration files to be included in compilation. */
 		// "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-		"esModuleInterop": true
+		"esModuleInterop": true,
 		// "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 
 		/* Source Map Options */
@@ -55,5 +56,8 @@
 		/* Experimental Options */
 		// "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
 		// "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+		"paths": {
+			"@components/*": ["./src/components/*"]
+		}
 	}
 }


### PR DESCRIPTION
This is a first draft for and fixes #34. It uses the path mapping of ts-transform-paths before attempting to resolve node modules to handle absolute paths.